### PR TITLE
fix: system multiple duplicate classnames

### DIFF
--- a/src/lib/system.ts
+++ b/src/lib/system.ts
@@ -171,21 +171,19 @@ export const _customSystem: Config = {
 const customSystem = styledSystem(_customSystem);
 
 export const system = p => css`
-  &&&& {
-    ${compose(
-      layout,
-      color,
-      space,
-      background,
-      border,
-      grid,
-      position,
-      shadow,
-      typography,
-      flexbox,
-      customSystem,
-    )(p)}
-  }
+  ${compose(
+    layout,
+    color,
+    space,
+    background,
+    border,
+    grid,
+    position,
+    shadow,
+    typography,
+    flexbox,
+    customSystem,
+  )(p)}
 `;
 type CSS = React.CSSProperties;
 type borderRadius = BorderRadiusProps['borderRadius'];


### PR DESCRIPTION
It used to add the current classname many times which makes it hard to override and is inefficient